### PR TITLE
feat(usage): make measurement ID and api secret configurable via envs

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openebs/lib-csi/pkg/common/errors"
 )
 
-var measurementIDMatcher = regexp.MustCompile(`^G-[a-zA-Z0-9]+$`)
+var MeasurementIDMatcher = regexp.MustCompile(`^G-[a-zA-Z0-9]+$`)
 
 type MeasurementClientOption func(*MeasurementClient) error
 
@@ -82,7 +82,7 @@ func WithMeasurementId(measurementId string) MeasurementClientOption {
 			return errors.Errorf("failed to set measurement_id: id is an empty string")
 		}
 
-		if !measurementIDMatcher.MatchString(measurementId) {
+		if !MeasurementIDMatcher.MatchString(measurementId) {
 			return errors.Errorf("Invalid measurement_id: %s", measurementId)
 		}
 

--- a/usage/const.go
+++ b/usage/const.go
@@ -1,10 +1,10 @@
 package usage
 
 const (
-	// MeasurementId is the unique code of the OpenEBS property in Google Analytics.
-	MeasurementId string = "G-TZGP46618W"
-	// ApiSecret is the measurement protocol api_secret.
-	ApiSecret string = "91JGdTg9QwGn7Y-vvuM4zA"
+	// DefaultMeasurementId is the default unique code of the OpenEBS property in Google Analytics.
+	DefaultMeasurementId string = "G-TZGP46618W"
+	// DefaultApiSecret is the default measurement protocol api_secret.
+	DefaultApiSecret string = "91JGdTg9QwGn7Y-vvuM4zA"
 
 	// InstallEvent event is sent on pod starts
 	InstallEvent string = "install"
@@ -26,4 +26,9 @@ const (
 	EventLabelNode string = "nodes"
 	// EventLabelCapacity holds the string label "capacity"
 	EventLabelCapacity string = "capacity"
+
+	// MeasurementIdEnv sets the measurement ID for the target GA4 property.
+	MeasurementIdEnv = "GA_ID"
+	// ApiSecretEnv sets the measurement protocol API secret for the target GA4 property.
+	ApiSecretEnv = "GA_KEY"
 )

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,0 +1,132 @@
+package usage
+
+import (
+	"encoding/base64"
+	"os"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestApiCreds(t *testing.T) {
+	testCases := map[string]struct {
+		idEnvValue     string
+		idSet          bool
+		secretEnvValue string
+		secretSet      bool
+		expectedId     string
+		expectedSecret string
+	}{
+		"Missing both ENVs": {
+			idEnvValue:     "",
+			idSet:          false,
+			secretEnvValue: "",
+			secretSet:      false,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Missing id ENV": {
+			idEnvValue:     "",
+			idSet:          false,
+			secretEnvValue: base64.StdEncoding.EncodeToString([]byte("testSecret")),
+			secretSet:      true,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Missing secret ENV": {
+			idEnvValue:     base64.StdEncoding.EncodeToString([]byte("G-testId")),
+			idSet:          true,
+			secretEnvValue: "",
+			secretSet:      false,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Empty id ENV": {
+			idEnvValue:     "",
+			idSet:          true,
+			secretEnvValue: base64.StdEncoding.EncodeToString([]byte("testSecret")),
+			secretSet:      true,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Empty secret ENV": {
+			idEnvValue:     base64.StdEncoding.EncodeToString([]byte("G-testId")),
+			idSet:          true,
+			secretEnvValue: "",
+			secretSet:      true,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Invalid base64 value for id ENV": {
+			idEnvValue:     trimLastChar(base64.StdEncoding.EncodeToString([]byte("G-testId"))),
+			idSet:          true,
+			secretEnvValue: base64.StdEncoding.EncodeToString([]byte("testSecret")),
+			secretSet:      true,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Invalid base64 value for secret ENV": {
+			idEnvValue:     base64.StdEncoding.EncodeToString([]byte("testId")),
+			idSet:          true,
+			secretEnvValue: trimLastChar(base64.StdEncoding.EncodeToString([]byte("testSecret"))),
+			secretSet:      true,
+			expectedId:     DefaultMeasurementId,
+			expectedSecret: DefaultApiSecret,
+		},
+		"Valid ENVs set": {
+			idEnvValue:     base64.StdEncoding.EncodeToString([]byte("G-testId")),
+			idSet:          true,
+			secretEnvValue: base64.StdEncoding.EncodeToString([]byte("testSecret")),
+			secretSet:      true,
+			expectedId:     "G-testId",
+			expectedSecret: "testSecret",
+		},
+	}
+
+	for k, v := range testCases {
+		k, v := k, v
+		t.Run(k, func(t *testing.T) {
+			if v.idSet {
+				if os.Setenv(MeasurementIdEnv, v.idEnvValue) != nil {
+					t.Errorf("failed to set env '%s' to '%s' for test case '%s'",
+						MeasurementIdEnv, v.idEnvValue, k,
+					)
+				}
+			} else {
+				if os.Unsetenv(MeasurementIdEnv) != nil {
+					t.Errorf("failed to unset env '%s' for test case '%s'", MeasurementIdEnv, k)
+				}
+			}
+			if v.secretSet {
+				if os.Setenv(ApiSecretEnv, v.secretEnvValue) != nil {
+					t.Errorf("failed to set env '%s' to '%s' for test case '%s'",
+						ApiSecretEnv, v.secretEnvValue, k,
+					)
+				}
+			} else {
+				if os.Unsetenv(ApiSecretEnv) != nil {
+					t.Errorf("failed to unset env '%s' for test case '%s'", ApiSecretEnv, k)
+				}
+			}
+			observedId, observedSecret := apiCreds()
+			if !reflect.DeepEqual(observedId, v.expectedId) {
+				t.Errorf("apiCreds() id mismatch: expected '%s', observed '%s'",
+					v.expectedId, observedId,
+				)
+			}
+			if !reflect.DeepEqual(observedSecret, v.expectedSecret) {
+				t.Errorf("apiCreds() secret mismatch: expected '%s', observed '%s'",
+					v.expectedSecret, observedSecret,
+				)
+			}
+		})
+	}
+}
+
+func trimLastChar(s string) string {
+	r, size := utf8.DecodeLastRuneInString(s)
+	if r == utf8.RuneError && (size == 0 || size == 1) {
+		size = 0
+	}
+	return s[:len(s)-size]
+}


### PR DESCRIPTION
This change makes the GA-4 measurement ID and api secret configurable via ENVs:
- `GA_ID` --> measurement ID
- `GA_KEY` --> api secret

The values must be in base64 (padded/non-padded).

The default measurement ID and api secret are used as fallback if...
- at least one of the envs are unset
- at least one of the envs are empty
- at least one of the envs' value is not a valid base64 (as per Go standard library)
- the measurement ID doesn't match the regex for a valid measurement ID