### PR TITLE
fix: accept portless GA_DNS and stop New() returning nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,40 @@ Create a new `client` and `Send()` an 'event'.
 
 	![foo-ga](https://cloud.githubusercontent.com/assets/633843/5979585/023fc580-a8fd-11e4-803a-956610bcc2e2.png)
 
+### Configuration
+
+The `usage` package reads the following environment variables. All of them are
+optional.
+
+| Variable | Description |
+| --- | --- |
+| `GA_ID` | base64-encoded GA4 Measurement ID for the target property. |
+| `GA_KEY` | base64-encoded Measurement Protocol API secret for the target property. |
+| `GA_DNS` | DNS server used to resolve `www.google-analytics.com`. When unset, the system resolver is used. |
+| `OPENEBS_IO_ANALYTICS_PING_INTERVAL` | Interval between ping events (default `24h`, minimum `1h`). |
+
+`GA_ID` and `GA_KEY` take effect only when **both** are set and decode to a
+valid Measurement ID; otherwise the built-in defaults are used and events are
+reported to the upstream OpenEBS property.
+
+#### `GA_DNS`
+
+Set this when the pod cannot use the cluster resolver to reach Google Analytics.
+The port is optional and defaults to `53`. The host must be an IP address, not a
+hostname:
+
+```
+GA_DNS=8.8.8.8                       # -> 8.8.8.8:53
+GA_DNS=8.8.8.8:5353
+GA_DNS=2001:4860:4860::8888          # -> [2001:4860:4860::8888]:53
+GA_DNS=[2001:4860:4860::8888]:5353
+```
+
+Telemetry is best-effort, so an unparseable `GA_DNS` does not stop the client
+from being created: the value is rejected, an error is logged, and the system
+resolver is used instead. If events stop arriving after setting `GA_DNS`, check
+the logs for `failed to create http client` — a value that is accepted but
+points at an unreachable server fails silently at send time.
+
 ## License Compliance
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopenebs%2Fgoogle-analytics-4.svg?type=large&issueType=license)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopenebs%2Fgoogle-analytics-4?ref=badge_large&issueType=license)

--- a/example/main.go
+++ b/example/main.go
@@ -5,15 +5,22 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/openebs/google-analytics-4/internal/dnsaddr"
 	gaClient "github.com/openebs/google-analytics-4/pkg/client"
 	gaEvent "github.com/openebs/google-analytics-4/pkg/event"
 )
 
+// httpClientWithDns returns an HTTP client whose resolver queries the given DNS
+// server instead of the system default. See dnsaddr.Normalize for the accepted
+// address formats.
 func httpClientWithDns(dns string) (*http.Client, error) {
-	if _, _, err := net.SplitHostPort(dns); err != nil {
-		return nil, fmt.Errorf("invalid dns address %q: must be host:port", dns)
+	addr, err := dnsaddr.Normalize(dns)
+	if err != nil {
+		return nil, err
 	}
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -22,7 +29,7 @@ func httpClientWithDns(dns string) (*http.Client, error) {
 			PreferGo: true,
 			Dial: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				d := net.Dialer{Timeout: 5 * time.Second}
-				return d.DialContext(ctx, network, dns)
+				return d.DialContext(ctx, network, addr)
 			},
 		},
 	}
@@ -34,15 +41,19 @@ func httpClientWithDns(dns string) (*http.Client, error) {
 func main() {
 
 	opts := []gaClient.MeasurementClientOption{
+		// pkg/client takes these verbatim -- do not base64-encode them. Only the
+		// usage package's GA_KEY/GA_ID env vars are base64-decoded.
 		gaClient.WithApiSecret("<api-secret>"),
 		gaClient.WithMeasurementId("<measurement-id>"),
 		gaClient.WithClientId("1b803d56-fde0-4f1e-ab64-ccb22509ae9f"),
 	}
 
 	// Only configure a custom HTTP client (with a DNS override) when a DNS
-	// address is set. When it's empty, skip the option so the measurement
-	// client falls back to its default HTTP transport.
-	dns := "<dns>"
+	// address is set. When it's empty -- the default when GA_DNS is unset --
+	// skip the option so the measurement client falls back to its default HTTP
+	// transport. Export GA_DNS=8.8.8.8 (the port is optional) to resolve
+	// through a specific server instead.
+	dns := strings.TrimSpace(os.Getenv("GA_DNS"))
 	if dns != "" {
 		httpClient, err := httpClientWithDns(dns)
 		if err != nil {

--- a/internal/dnsaddr/dnsaddr.go
+++ b/internal/dnsaddr/dnsaddr.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dnsaddr normalizes DNS server addresses. It is internal so that the
+// usage package and the example share one implementation: they previously kept
+// separate copies that drifted apart.
+package dnsaddr
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// DefaultPort is applied when an address carries no port of its own.
+const DefaultPort = "53"
+
+// Normalize accepts a DNS server address with or without a port and returns it
+// in host:port form, defaulting the port to 53 when omitted. Accepted forms:
+//
+//	8.8.8.8                      -> 8.8.8.8:53
+//	8.8.8.8:5353                 -> 8.8.8.8:5353
+//	2001:4860:4860::8888         -> [2001:4860:4860::8888]:53
+//	[2001:4860:4860::8888]       -> [2001:4860:4860::8888]:53
+//	[2001:4860:4860::8888]:5353  -> [2001:4860:4860::8888]:5353
+//
+// Surrounding whitespace is trimmed. The host must be a valid IP address —
+// hostnames are rejected because resolving the resolver's own address would be
+// circular. The port must be a plain decimal in the range 1-65535; port 0 is
+// rejected because it dials successfully but silently discards every query.
+func Normalize(dns string) (string, error) {
+	dns = strings.TrimSpace(dns)
+	if dns == "" {
+		return "", errors.New("empty dns address")
+	}
+
+	host, port, err := net.SplitHostPort(dns)
+	if err != nil {
+		// No parseable port present: treat the whole value as a bare host and
+		// apply the default DNS port. A bare IPv6 may still be bracketed
+		// ("[::1]"), which SplitHostPort rejects for having no port.
+		host, port = strings.TrimSuffix(strings.TrimPrefix(dns, "["), "]"), DefaultPort
+	}
+	if port == "" {
+		port = DefaultPort
+	}
+
+	if net.ParseIP(host) == nil {
+		return "", fmt.Errorf("invalid dns address %q: host must be a valid IP address", dns)
+	}
+	// ParseUint (unlike Atoi) rejects a sign prefix, so "+53" and "-1" do not
+	// slip through as valid ports, and the bitSize caps the value at 65535.
+	p, perr := strconv.ParseUint(port, 10, 16)
+	if perr != nil || p == 0 {
+		return "", fmt.Errorf("invalid dns address %q: port must be in the range 1-65535", dns)
+	}
+
+	// net.JoinHostPort brackets IPv6 hosts as needed.
+	return net.JoinHostPort(host, strconv.FormatUint(p, 10)), nil
+}

--- a/internal/dnsaddr/dnsaddr_test.go
+++ b/internal/dnsaddr/dnsaddr_test.go
@@ -1,0 +1,77 @@
+package dnsaddr
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"bare ipv4", "8.8.8.8", "8.8.8.8:53", false},
+		{"ipv4 with port", "8.8.8.8:5353", "8.8.8.8:5353", false},
+		{"ipv4 trailing colon", "8.8.8.8:", "8.8.8.8:53", false},
+		{"bare ipv6", "2001:4860:4860::8888", "[2001:4860:4860::8888]:53", false},
+		{"bracketed ipv6 no port", "[2001:4860:4860::8888]", "[2001:4860:4860::8888]:53", false},
+		{"bracketed ipv6 with port", "[2001:4860:4860::8888]:53", "[2001:4860:4860::8888]:53", false},
+		{"ipv6 loopback bracketed", "[::1]", "[::1]:53", false},
+		{"ipv4 mapped ipv6", "::ffff:8.8.8.8", "[::ffff:8.8.8.8]:53", false},
+		{"ipv6 ending in port-like group", "2001:db8::1:53", "[2001:db8::1:53]:53", false},
+		{"whitespace trimmed", "  8.8.8.8  ", "8.8.8.8:53", false},
+		{"empty", "", "", true},
+		{"whitespace only", "   ", "", true},
+		{"non-ip host", "dns.example.com", "", true},
+		{"non-ip host with port", "dns.example.com:53", "", true},
+		{"port lower boundary", "8.8.8.8:1", "8.8.8.8:1", false},
+		{"port upper boundary", "8.8.8.8:65535", "8.8.8.8:65535", false},
+		// Port 0 dials without error but every query is discarded, so it must
+		// not pass validation.
+		{"port zero", "8.8.8.8:0", "", true},
+		{"port just over max", "8.8.8.8:65536", "", true},
+		{"port out of range", "8.8.8.8:70000", "", true},
+		{"negative port", "8.8.8.8:-1", "", true},
+		{"signed port", "8.8.8.8:+53", "", true},
+		{"non-numeric port", "8.8.8.8:abc", "", true},
+		{"named port", "8.8.8.8:domain", "", true},
+		{"invalid ipv4 octet", "256.256.256.256", "", true},
+		{"too many ipv4 octets", "1.2.3.4.5", "", true},
+		{"unbracketed ipv6 with port", "2001:db8::1:5353:9999:1:2:3:4", "", true},
+		{"garbage", "not-an-ip", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Normalize(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Normalize(%q): expected error, got nil (result %q)", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q): unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeIsIdempotent guards the contract that the returned value is
+// already canonical: feeding it back must not change it.
+func TestNormalizeIsIdempotent(t *testing.T) {
+	for _, in := range []string{"8.8.8.8", "  8.8.8.8:5353 ", "[::1]", "2001:db8::1"} {
+		once, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("Normalize(%q): unexpected error: %v", in, err)
+		}
+		twice, err := Normalize(once)
+		if err != nil {
+			t.Fatalf("Normalize(%q) (second pass on %q): unexpected error: %v", once, in, err)
+		}
+		if once != twice {
+			t.Errorf("Normalize not idempotent for %q: %q -> %q", in, once, twice)
+		}
+	}
+}

--- a/usage/const.go
+++ b/usage/const.go
@@ -30,6 +30,8 @@ const (
 	MeasurementIdEnv = "GA_ID"
 	// ApiSecretEnv sets the measurement protocol API secret for the target GA4 property.
 	ApiSecretEnv = "GA_KEY"
-	// DnsEnv sets the DNS server address (host:port) used by the GA client resolver (e.g., "8.8.8.8:53").
+	// DnsEnv sets the DNS server address used by the GA client resolver. The
+	// port is optional and defaults to 53, so both "8.8.8.8" and "8.8.8.8:53"
+	// are accepted (as are bare and bracketed IPv6 addresses).
 	DnsEnv = "GA_DNS"
 )

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -62,7 +62,11 @@ type Usage struct {
 	AnalyticsClient *ga4Client.MeasurementClient
 }
 
-// New returns an instance of Usage
+// New returns an instance of Usage. It never returns nil: callers chain
+// directly off it (New().CommonBuild(...).Send()), so a misconfigured
+// environment must degrade telemetry rather than panic the importing process.
+// When the analytics client cannot be built, the returned Usage still accepts
+// every builder call and Send simply drops the event.
 func New() *Usage {
 	measurementId, apiSecret := apiCreds()
 
@@ -73,20 +77,23 @@ func New() *Usage {
 
 	// Only configure a custom HTTP client (with a DNS override) when a DNS
 	// address is set. When it's empty, skip the option so the measurement
-	// client falls back to its default HTTP transport.
+	// client falls back to its default HTTP transport. A malformed address is
+	// treated the same way: telemetry is best-effort, so a misconfigured env
+	// var must not stop the client from being created.
 	if dns := env.Get(DnsEnv); dns != "" {
 		httpClient, err := httpClientWithDns(dns)
 		if err != nil {
-			klog.Errorf("failed to create http client: %v", err)
-			return nil
+			klog.Errorf("failed to create http client, falling back to the default resolver: %v", err)
+		} else {
+			opts = append(opts, ga4Client.WithHttpClient(httpClient))
 		}
-		opts = append(opts, ga4Client.WithHttpClient(httpClient))
 	}
 
+	// A nil AnalyticsClient disables sending; the event builder stays usable so
+	// the caller's chain completes without a nil dereference.
 	client, err := ga4Client.NewMeasurementClient(opts...)
 	if err != nil {
-		klog.Errorf("failed to create measurement client: %v", err)
-		return nil
+		klog.Errorf("failed to create measurement client, telemetry is disabled: %v", err)
 	}
 	openebsEventBuilder := ga4Event.NewOpenebsEventBuilder()
 	return &Usage{AnalyticsClient: client, OpenebsEventBuilder: openebsEventBuilder}
@@ -154,7 +161,9 @@ func (u *Usage) ApplicationBuilder() *Usage {
 	v := NewVersion()
 	_ = v.getVersion(false)
 
-	u.AnalyticsClient.SetClientId(v.id)
+	if u.AnalyticsClient != nil {
+		u.AnalyticsClient.SetClientId(v.id)
+	}
 	u.OpenebsEventBuilder.K8sDefaultNsUid(v.id)
 
 	return u
@@ -166,7 +175,9 @@ func (u *Usage) InstallBuilder(override bool) *Usage {
 	clusterSize, _ := k8sapi.NumberOfNodes()
 	_ = v.getVersion(override)
 
-	u.AnalyticsClient.SetClientId(v.id)
+	if u.AnalyticsClient != nil {
+		u.AnalyticsClient.SetClientId(v.id)
+	}
 	u.OpenebsEventBuilder.
 		K8sDefaultNsUid(v.id).
 		Category(InstallEvent).
@@ -177,9 +188,14 @@ func (u *Usage) InstallBuilder(override bool) *Usage {
 
 // Send POSTS an event over to the GA4 API
 func (u *Usage) Send() {
+	client := u.AnalyticsClient
+	if client == nil {
+		klog.V(4).Info("skipping event: analytics client is not configured")
+		return
+	}
+
 	// Instantiate an analytics client
 	go func() {
-		client := u.AnalyticsClient
 		event := u.OpenebsEventBuilder.Build()
 
 		if err := client.Send(event); err != nil {

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -123,6 +123,69 @@ func TestApiCreds(t *testing.T) {
 	}
 }
 
+func TestNewDnsEnv(t *testing.T) {
+	// New must never return nil because of the DNS env var: consumers chain
+	// directly off it (analytics.New().CommonBuild(...)) and would panic.
+	testCases := map[string]struct {
+		dnsEnvValue string
+		dnsSet      bool
+		// customTransport is true when the DNS override is expected to be
+		// installed, false when New must fall back to the default transport.
+		customTransport bool
+	}{
+		"Missing dns ENV":    {dnsSet: false, customTransport: false},
+		"Empty dns ENV":      {dnsEnvValue: "", dnsSet: true, customTransport: false},
+		"Whitespace dns ENV": {dnsEnvValue: "   ", dnsSet: true, customTransport: false},
+		"Non-IP dns ENV":     {dnsEnvValue: "dns.example.com", dnsSet: true, customTransport: false},
+		"Bad port dns ENV":   {dnsEnvValue: "8.8.8.8:70000", dnsSet: true, customTransport: false},
+		"Zero port dns ENV":  {dnsEnvValue: "8.8.8.8:0", dnsSet: true, customTransport: false},
+		"Valid dns ENV":      {dnsEnvValue: "8.8.8.8", dnsSet: true, customTransport: true},
+		"Valid dns ENV port": {dnsEnvValue: "8.8.8.8:5353", dnsSet: true, customTransport: true},
+		"Valid ipv6 dns ENV": {dnsEnvValue: "[2001:4860:4860::8888]", dnsSet: true, customTransport: true},
+	}
+
+	for k, v := range testCases {
+		k, v := k, v
+		t.Run(k, func(t *testing.T) {
+			// Use the default measurement credentials for every case; t.Setenv
+			// restores whatever the environment held before.
+			t.Setenv(MeasurementIdEnv, "")
+			t.Setenv(ApiSecretEnv, "")
+			if v.dnsSet {
+				t.Setenv(DnsEnv, v.dnsEnvValue)
+			} else {
+				t.Setenv(DnsEnv, "")
+				if err := os.Unsetenv(DnsEnv); err != nil {
+					t.Fatalf("failed to unset env '%s': %v", DnsEnv, err)
+				}
+			}
+
+			u := New()
+			if u == nil {
+				t.Fatalf("New() returned nil for test case '%s'", k)
+			}
+			if u.OpenebsEventBuilder == nil {
+				t.Errorf("New() returned a nil OpenebsEventBuilder for test case '%s'", k)
+			}
+			if u.AnalyticsClient == nil {
+				t.Fatalf("New() returned a nil AnalyticsClient for test case '%s'", k)
+			}
+			if u.AnalyticsClient.HttpClient == nil {
+				t.Fatalf("New() returned a nil HttpClient for test case '%s'", k)
+			}
+
+			// The DNS override is only observable as a transport that differs
+			// from the stock one, so assert on that rather than on non-nilness.
+			isCustom := u.AnalyticsClient.HttpClient.Transport != nil
+			if isCustom != v.customTransport {
+				t.Errorf("test case '%s': custom transport installed = %v, want %v",
+					k, isCustom, v.customTransport,
+				)
+			}
+		})
+	}
+}
+
 func trimLastChar(s string) string {
 	r, size := utf8.DecodeLastRuneInString(s)
 	if r == utf8.RuneError && (size == 0 || size == 1) {

--- a/usage/utils.go
+++ b/usage/utils.go
@@ -24,11 +24,19 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+
+	"github.com/openebs/google-analytics-4/internal/dnsaddr"
 )
 
+// httpClientWithDns returns an HTTP client whose resolver queries the given DNS
+// server instead of the system default. See dnsaddr.Normalize for the accepted
+// address formats.
 func httpClientWithDns(dns string) (*http.Client, error) {
-	if _, _, err := net.SplitHostPort(dns); err != nil {
-		return nil, fmt.Errorf("invalid %s address %q: must be host:port", DnsEnv, dns)
+	addr, err := dnsaddr.Normalize(dns)
+	if err != nil {
+		// Name the env var here so operators know which setting to correct;
+		// dnsaddr stays generic for the example's sake.
+		return nil, fmt.Errorf("%s: %w", DnsEnv, err)
 	}
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -37,7 +45,7 @@ func httpClientWithDns(dns string) (*http.Client, error) {
 			PreferGo: true,
 			Dial: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				d := net.Dialer{Timeout: 5 * time.Second}
-				return d.DialContext(ctx, network, dns)
+				return d.DialContext(ctx, network, addr)
 			},
 		},
 	}

--- a/usage/utils_test.go
+++ b/usage/utils_test.go
@@ -4,13 +4,64 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
 
+// fakeDNSServer starts a UDP listener that stands in for a DNS server and
+// returns its address plus a channel closed when it receives a packet.
+func fakeDNSServer(t *testing.T) (addr string, contacted <-chan struct{}) {
+	t.Helper()
+
+	listener, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start UDP listener: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	ch := make(chan struct{})
+	go func() {
+		buf := make([]byte, 512)
+		if _, _, err := listener.ReadFrom(buf); err == nil {
+			close(ch)
+		}
+	}()
+
+	return listener.LocalAddr().String(), ch
+}
+
+// assertResolverContacts dials a hostname through client and reports whether the
+// custom resolver reached the fake DNS server. The dial itself is expected to
+// fail — only the resolver traffic matters.
+func assertResolverContacts(t *testing.T, client *http.Client, contacted <-chan struct{}) {
+	t.Helper()
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		conn, err := transport.DialContext(ctx, "tcp", "nonexistent.test:80")
+		if err == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	select {
+	case <-contacted:
+		// custom DNS server was reached — resolver is correctly wired
+	case <-time.After(5 * time.Second):
+		t.Fatal("custom DNS server was never contacted — resolver not wired")
+	}
+}
+
 func TestHttpClientWithDns_EmptyDNS(t *testing.T) {
-	// An empty DNS address is no longer handled here (the fallback to the
-	// default transport lives in New); it must be rejected as invalid.
+	// An empty DNS address is not handled here (the fallback to the default
+	// transport lives in New); it must be rejected as invalid.
 	_, err := httpClientWithDns("")
 	if err == nil {
 		t.Fatal("expected error for empty DNS address, got nil")
@@ -18,50 +69,57 @@ func TestHttpClientWithDns_EmptyDNS(t *testing.T) {
 }
 
 func TestHttpClientWithDns_WithDNS(t *testing.T) {
-	// Start a local UDP listener acting as the fake DNS server.
-	listener, err := net.ListenPacket("udp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to start UDP listener: %v", err)
-	}
-	defer listener.Close()
+	addr, contacted := fakeDNSServer(t)
 
-	client, err := httpClientWithDns(listener.LocalAddr().String())
+	client, err := httpClientWithDns(addr)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected *http.Transport")
+	assertResolverContacts(t, client, contacted)
+}
+
+// TestHttpClientWithDns_DialsNormalizedAddr pins the resolver to the normalized
+// address rather than the raw input: the untrimmed form below is not dialable,
+// so the fake DNS server is only reached if normalization is applied first.
+func TestHttpClientWithDns_DialsNormalizedAddr(t *testing.T) {
+	addr, contacted := fakeDNSServer(t)
+
+	padded := "  " + addr + "  "
+	if _, err := net.Dial("udp", padded); err == nil {
+		t.Fatalf("precondition failed: %q is unexpectedly dialable as-is", padded)
 	}
 
-	// contacted is closed when the fake DNS server receives a packet.
-	contacted := make(chan struct{})
-	go func() {
-		buf := make([]byte, 512)
-		_ = listener.SetReadDeadline(time.Now().Add(2 * time.Second))
-		if _, _, err := listener.ReadFrom(buf); err == nil {
-			close(contacted)
-		}
-	}()
+	client, err := httpClientWithDns(padded)
+	if err != nil {
+		t.Fatalf("expected no error for %q, got %v", padded, err)
+	}
+	assertResolverContacts(t, client, contacted)
+}
 
-	// Dialing a hostname (not an IP) forces the custom resolver to contact our
-	// fake DNS server. The dial itself will fail — that's expected.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	transport.DialContext(ctx, "tcp", "nonexistent.test:80")
-
-	select {
-	case <-contacted:
-		// custom DNS server was reached — resolver is correctly wired
-	case <-time.After(2 * time.Second):
-		t.Fatal("custom DNS server was never contacted — resolver not wired")
+func TestHttpClientWithDns_NoPort(t *testing.T) {
+	// A bare IP without a port is accepted; the port defaults to 53.
+	client, err := httpClientWithDns("8.8.8.8")
+	if err != nil {
+		t.Fatalf("expected no error for portless DNS address, got %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
 	}
 }
 
 func TestHttpClientWithDns_InvalidDNS(t *testing.T) {
-	_, err := httpClientWithDns("8.8.8.8")
-	if err == nil {
-		t.Fatal("expected error for DNS address missing port, got nil")
+	// Rejected inputs are covered exhaustively by the dnsaddr package tests;
+	// here we only check that a bad value is refused and that the message names
+	// the env var an operator has to fix.
+	for _, in := range []string{"not-an-ip", "dns.example.com", "8.8.8.8:0", "8.8.8.8:70000"} {
+		_, err := httpClientWithDns(in)
+		if err == nil {
+			t.Errorf("expected error for DNS address %q, got nil", in)
+			continue
+		}
+		if !strings.Contains(err.Error(), DnsEnv) {
+			t.Errorf("error for %q does not mention %s: %v", in, DnsEnv, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/openebs/google-analytics-4/pull/20, which left two rough edges:

- GA_DNS required host:port, so GA_DNS=8.8.8.8 was rejected. Add
  internal/dnsaddr with Normalize(), shared by the usage package and the
  example, which had drifted copies. It accepts bare and bracketed IPv4
  and IPv6 hosts and defaults the port to 53.
- New() returned nil on a bad GA_DNS or a failed measurement client,
  which panicked callers chaining off it. Telemetry is now best-effort:
  a bad GA_DNS falls back to the system resolver, and a failed
  measurement client leaves AnalyticsClient nil so Send() drops the
  event while the builder chain stays usable.